### PR TITLE
Update to latest embedded and box big data to avoid stack overflow

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["embedded-graphics", "graphics", "embedded", "push2"]
 repository = "https://github.com/mbracher/push2_display"
 
 [dependencies]
-embedded-graphics-core = "0.1.1"
+embedded-graphics-core = "0.2.0"
 rusb = "0.6"
 thiserror = "1.0.22"
 
@@ -19,5 +19,5 @@ thiserror = "1.0.22"
 name = "hello"
 
 [dev_dependencies]
-embedded-graphics = "0.7.0-alpha.2"
+embedded-graphics = "0.7.0-alpha.3"
 

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -3,11 +3,11 @@
 //! A simple example displaying some graphics and text on the Ableton Push2 display.
 
 use embedded_graphics::{
-    fonts::{Font12x16, Text},
+    mono_font::{ascii::{Font10x20}, MonoTextStyle, MonoTextStyleBuilder},
     pixelcolor::{Bgr565},
 
-    primitives::Rectangle,
-    style:: {PrimitiveStyle, MonoTextStyle},
+    primitives::{Rectangle, PrimitiveStyle},
+    text::Text,
     prelude::*,
 };
 use push2_display::Push2Display;
@@ -20,7 +20,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
     let mut step = 4;
     loop {
         display.clear(Bgr565::BLACK)?;
-
+        let text_style = MonoTextStyle::new(Font10x20, Bgr565::WHITE);
         Rectangle::new(Point::zero(), display.size())
             .into_styled(PrimitiveStyle::with_stroke(Bgr565::WHITE, 1))
             .draw(&mut display)?;
@@ -31,7 +31,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
         }
 
         Text::new("Hello!", position)
-            .into_styled(MonoTextStyle::new(Font12x16, Bgr565::BLUE))
+            .into_styled(text_style)
             .draw(&mut display)?;
 
         display.flush()?; // if no frame arrives in 2 seconds, the display is turned black

--- a/src/display.rs
+++ b/src/display.rs
@@ -9,7 +9,7 @@ use thiserror::Error;
 
 pub struct Push2Display {
     handle: DeviceHandle<Context>,
-    frame_buffer: [u16; DISPLAY_WIDTH * DISPLAY_HEIGHT],
+    frame_buffer: Box<[u16]>,
 }
 
 #[derive(Error, Debug)]
@@ -52,7 +52,7 @@ impl Push2Display {
         let (_, _, mut handle) = open_device(&mut context, PUSH_2_VENDOR_ID, PUSH_2_PRODUCT_ID).ok_or( Push2DisplayError::Push2NotFound)?;
 
         handle.claim_interface(0)?;
-        let buffer : [u16; DISPLAY_WIDTH * DISPLAY_HEIGHT] = [0; DISPLAY_WIDTH * DISPLAY_HEIGHT];
+        let buffer: Box<[u16]>  = vec![0;DISPLAY_WIDTH * DISPLAY_HEIGHT].into_boxed_slice();
 
         Ok(Push2Display {
             handle,


### PR DESCRIPTION
- update to the latest version of embedded-graphics.
- Have the framebuffer as a Boxed slice instead of an array to avoid stack overflow.

I tried the example and it did not work, so I updated some stuff and it worked again. Not sure if you are accepting Pull Requests, but would like to try and help.

Thank you!