### PR TITLE
Update dependencies and changelog. bump version to 1.0.0-alpha.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -
 
+## [1.0.0-alpha.3] - 2022-04-22
+
+### Changed
+
+- Updated embedded-graphics-core to 0.3.3
+- Updated rusb to 0.9.1
+- Updated thiserror to 1.0.30
+- For hello example, update embedded-graphics to 0.7.1
+
 ## [1.0.0-alpha.2] - 2021-02-22
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "push2_display"
-version = "1.0.0-alpha.2"
+version = "1.0.0-alpha.3"
 authors = ["Marc Bracher"]
 edition = "2018"
 description="Ableton Push2 Embedded-graphics display driver"
@@ -10,14 +10,14 @@ keywords = ["embedded-graphics", "graphics", "embedded", "push2"]
 repository = "https://github.com/mbracher/push2_display"
 
 [dependencies]
-embedded-graphics-core = "0.2.0"
-rusb = "0.6"
-thiserror = "1.0.22"
+embedded-graphics-core = "0.3.3"
+rusb = "0.9.1"
+thiserror = "1.0.30"
 
 
 [[example]]
 name = "hello"
 
 [dev_dependencies]
-embedded-graphics = "0.7.0-alpha.3"
+embedded-graphics = "0.7.1"
 

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -3,7 +3,7 @@
 //! A simple example displaying some graphics and text on the Ableton Push2 display.
 
 use embedded_graphics::{
-    mono_font::{ascii::Font10x20, MonoTextStyle},
+    mono_font::{ascii::FONT_10X20, MonoTextStyle},
     pixelcolor::Bgr565,
     prelude::*,
     primitives::{PrimitiveStyle, Rectangle},
@@ -19,7 +19,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
     let mut step = 4;
     loop {
         display.clear(Bgr565::BLACK)?;
-        let text_style = MonoTextStyle::new(Font10x20, Bgr565::WHITE);
+        let text_style = MonoTextStyle::new(&FONT_10X20, Bgr565::WHITE);
         Rectangle::new(Point::zero(), display.size())
             .into_styled(PrimitiveStyle::with_stroke(Bgr565::WHITE, 1))
             .draw(&mut display)?;
@@ -29,8 +29,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
             step *= -1;
         }
 
-        Text::new("Hello!", position)
-            .into_styled(text_style)
+        Text::new("Hello!", position, text_style)
             .draw(&mut display)?;
 
         display.flush()?; // if no frame arrives in 2 seconds, the display is turned black


### PR DESCRIPTION
Hello,
while using this library I noticed conflicts with dependency versions.
I have updated all dependencies of push2_display to the currently newest stable versions and tested both the example and my own code to still work.
I bumped the version on the smallest scale since no API was changed on the push2_display side, only the example had some minor changes at all.
I added the changes to the changelog so I hope I got everything you need to maybe release an update to creates.io without too much hassle for you.