### PR TITLE
Bump dependency versions to currently newest version, no code changes.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["embedded-graphics", "graphics", "embedded", "push2"]
 repository = "https://github.com/mbracher/push2_display"
 
 [dependencies]
-embedded-graphics-core = "0.3.3"
+embedded-graphics-core = "0.4.*"
 rusb = "0.9.1"
 thiserror = "1.0.30"
 
@@ -19,5 +19,5 @@ thiserror = "1.0.30"
 name = "hello"
 
 [dev_dependencies]
-embedded-graphics = "0.7.1"
+embedded-graphics = "0.8.*"
 


### PR DESCRIPTION
Hello,
I know your last change to the repo is quite a while ago, but I recently wanted to fix and change something on my soundboard, and ran into some version-incompatibilites. A simple version bump in your Cargo.toml fixed it, no additional changes.

I don't mind depending on my own git repo, but it would also be nice if you would merge and publish the version bump. 

Thank you for your time.